### PR TITLE
Update bot_command_scope_chat.dart

### DIFF
--- a/lib/src/entities/telegram/bot_command_scope_chat.dart
+++ b/lib/src/entities/telegram/bot_command_scope_chat.dart
@@ -8,7 +8,7 @@ class BotCommandScopeChat extends BotCommandScope {
   final String type = 'chat';
 
   /// Unique identifier for the target chat or username of the target supergroup
-  ChatID chatId;
+  int chatId;  
 
   /// Basic constructor
   BotCommandScopeChat(this.chatId);


### PR DESCRIPTION
// if stay ChatID, we will get The argument type 'Map<dynamic, dynamic>' can't be assigned to the parameter type 'BotCommandScope?' exception, need change in this class or ChatID class